### PR TITLE
Add RefValMut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+Unreleased
+----------
+- Added `RefValMut`, similar `RefVal` but with ref cell borrowed mutably
+
+
 0.1.6
 -----
 - Added `map` method to `RefVal` struct

--- a/src/fmt/mod.rs
+++ b/src/fmt/mod.rs
@@ -21,6 +21,7 @@ use crate::cell::Ref;
 use crate::cell::RefCell;
 use crate::cell::RefMut;
 use crate::cell::RefVal;
+use crate::RefValMut;
 
 
 impl<T: ?Sized + Debug> Debug for RefCell<T> {
@@ -63,6 +64,12 @@ impl<T: ?Sized + Debug> Debug for RefMut<'_, T> {
 }
 
 impl<T: Sized + Debug> Debug for RefVal<'_, T> {
+    fn fmt(&self, f: &mut Formatter) -> Result {
+        Debug::fmt(&*(self.deref()), f)
+    }
+}
+
+impl<T: Sized + Debug> Debug for RefValMut<'_, T> {
     fn fmt(&self, f: &mut Formatter) -> Result {
         Debug::fmt(&*(self.deref()), f)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,3 +31,4 @@ pub use crate::cell::Ref;
 pub use crate::cell::RefCell;
 pub use crate::cell::RefMut;
 pub use crate::cell::RefVal;
+pub use crate::cell::RefValMut;

--- a/tests/cell.rs
+++ b/tests/cell.rs
@@ -337,3 +337,26 @@ fn refval_map() {
     // Assert refcount == 0
     ref_strings.borrow_mut();
 }
+
+#[test]
+fn refvalmut() {
+    let ref_strings = RefCell::new(vec![
+        "one".to_owned(),
+        "two".to_owned(),
+        "three".to_owned(),
+    ]);
+
+    // `RefValMut` containing a mutable iterator over `ref_strings` strings
+    let mut it_1 = RefMut::map_val(RefCell::borrow_mut(&ref_strings), |v| v.iter_mut());
+    for ref mut s in it_1.by_ref() {
+        s.make_ascii_uppercase();
+    }
+    drop(it_1);
+
+    let strings = ref_strings.borrow();
+    assert_eq!(vec![
+        "ONE".to_owned(),
+        "TWO".to_owned(),
+        "THREE".to_owned(),
+    ], *strings);
+}


### PR DESCRIPTION
`RefValMut` is similar to `RefVal`, but borrows `RefCell` mutably.